### PR TITLE
Enable Account Locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ spec/rails-app/log
 
 initializers/authy.rb
 
+# For RBENV
+.ruby-version
+
+# For RubyMine
+.idea

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -36,8 +36,7 @@ class Devise::DeviseAuthyController < DeviseController
       set_flash_message(:notice, :signed_in) if is_navigational_format?
       respond_with resource, :location => after_sign_in_path_for(@resource)
     else
-      set_flash_message(:error, :invalid_token)
-      render :verify_authy
+      handle_invalid_token
     end
   end
 
@@ -130,15 +129,28 @@ class Devise::DeviseAuthyController < DeviseController
 
   protected
 
-    def after_authy_enabled_path_for(resource)
-      root_path
-    end
+  def after_authy_enabled_path_for(resource)
+    root_path
+  end
 
-    def after_authy_verified_path_for(resource)
-      after_authy_enabled_path_for(resource)
-    end
+  def after_authy_verified_path_for(resource)
+    after_authy_enabled_path_for(resource)
+  end
 
-    def invalid_resource_path
-      root_path
+  def invalid_resource_path
+    root_path
+  end
+
+  def handle_invalid_token
+    if @resource.respond_to?(:invalid_authy_attempt!) && @resource.invalid_authy_attempt!
+      after_account_is_locked
+    else
+      set_flash_message(:error, :invalid_token)
+      render :verify_authy
     end
+  end
+
+  def after_account_is_locked
+    sign_out_and_redirect @resource
+  end
 end

--- a/lib/devise-authy.rb
+++ b/lib/devise-authy.rb
@@ -20,5 +20,7 @@ end
 require 'devise-authy/routes'
 require 'devise-authy/rails'
 require 'devise-authy/models/authy_authenticatable'
+require 'devise-authy/models/authy_lockable'
 
 Devise.add_module :authy_authenticatable, :model => 'devise-authy/models/authy_authenticatable', :controller => :devise_authy, :route => :authy
+Devise.add_module :authy_lockable,        :model => 'devise-authy/models/authy_lockable'

--- a/lib/devise-authy/models/authy_lockable.rb
+++ b/lib/devise-authy/models/authy_lockable.rb
@@ -12,7 +12,7 @@ module Devise
       # Public: Determine if this is a lockable resource, via Devise::Models::Lockable.
       # Returns true
       def lockable?
-        respond_to? :lock_access!
+        respond_to?(:lock_access!) && Devise.lock_strategy == :failed_attempts
       end
 
       # Public: Handle a failed 2FA attempt. If the resource is lockable via
@@ -23,12 +23,12 @@ module Devise
         return false unless lockable?
 
         self.failed_attempts ||= 0
+        self.failed_attempts += 1
 
         if attempts_exceeded?
           lock_access! unless access_locked?
           true
         else
-          self.failed_attempts += 1
           save validate: false
           false
         end

--- a/lib/devise-authy/models/authy_lockable.rb
+++ b/lib/devise-authy/models/authy_lockable.rb
@@ -1,0 +1,41 @@
+module Devise
+
+  module Models
+
+    # Handles blocking a user access after a certain number of attempts.
+    # Requires proper configuration of the Devise::Models::Lockable module.
+    #
+    module AuthyLockable
+
+      extend ActiveSupport::Concern
+
+      # Public: Determine if this is a lockable resource, via Devise::Models::Lockable.
+      # Returns true
+      def lockable?
+        respond_to? :lock_access!
+      end
+
+      # Public: Handle a failed 2FA attempt. If the resource is lockable via
+      # Devise::Models::Lockable module then enforce that setting.
+      #
+      # Returns true if the user is locked out.
+      def invalid_authy_attempt!
+        return false unless lockable?
+
+        self.failed_attempts ||= 0
+
+        if attempts_exceeded?
+          lock_access! unless access_locked?
+          true
+        else
+          self.failed_attempts += 1
+          save validate: false
+          false
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/lib/devise-authy/models/authy_lockable.rb
+++ b/lib/devise-authy/models/authy_lockable.rb
@@ -11,8 +11,10 @@ module Devise
 
       # Public: Determine if this is a lockable resource, via Devise::Models::Lockable.
       # Returns true
+      # Raises an error if the Devise::Models::Lockable module is not configured.
       def lockable?
-        respond_to?(:lock_access!) && Devise.lock_strategy == :failed_attempts
+        raise 'Devise lockable extension required' unless respond_to? :lock_access!
+        Devise.lock_strategy == :failed_attempts
       end
 
       # Public: Handle a failed 2FA attempt. If the resource is lockable via

--- a/spec/features/authy_authenticatable_spec.rb
+++ b/spec/features/authy_authenticatable_spec.rb
@@ -26,7 +26,6 @@ describe "Authy Autnenticatable", :type => :request do
     end
 
     it "Sign in should succeed" do
-      visit new_user_session_path
       fill_sign_in_form(@user.email, '12345678')
       current_path.should == user_verify_authy_path
       page.should have_content('Please enter your Authy token')
@@ -42,7 +41,6 @@ describe "Authy Autnenticatable", :type => :request do
     end
 
     it "Sign in shouldn't succeed" do
-      visit new_user_session_path
       fill_sign_in_form(@user.email, '12345678')
       current_path.should == user_verify_authy_path
       page.should have_content('Please enter your Authy token')
@@ -60,7 +58,6 @@ describe "Authy Autnenticatable", :type => :request do
       it "Should prompt for a token" do
         cookie_val = sign_cookie("remember_device", Time.now.to_i - 2.month.to_i)
         page.driver.browser.set_cookie("remember_device=#{cookie_val}")
-        visit new_user_session_path
         fill_sign_in_form(@user.email, '12345678')
         current_path.should == user_verify_authy_path
         page.should have_content('Please enter your Authy token')
@@ -69,7 +66,6 @@ describe "Authy Autnenticatable", :type => :request do
       it "Shouldn't prompt for a token" do
         cookie_val = sign_cookie("remember_device", Time.now.to_i)
         page.driver.browser.set_cookie("remember_device=#{cookie_val}")
-        visit new_user_session_path
         fill_sign_in_form(@user.email, '12345678')
         current_path.should == root_path
         page.should have_content("Signed in successfully.")
@@ -86,7 +82,6 @@ describe "Authy Autnenticatable", :type => :request do
     end
 
     it "Click link Request sms" do
-      visit new_user_session_path
       fill_sign_in_form(@user.email, '12345678')
       click_link 'Request SMS'
       page.should have_content("SMS token was sent")

--- a/spec/features/authy_lockable_spec.rb
+++ b/spec/features/authy_lockable_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe 'Authy Lockable' do
+
+  let(:user) do
+    u = create_lockable_user authy_id: 20, email: 'foo@bar.com'
+    u.update_attribute :authy_enabled, true
+    u
+  end
+
+  before :each do
+    fill_sign_in_form user.email, '12345678', '#new_lockable_user', new_lockable_user_session_path
+  end
+
+  context 'user enters incorrect code' do
+
+    context 'maximum failed attempts not exceeded' do
+
+      it 'renders verify_authy view' do
+        fill_verify_token_form invalid_authy_token
+        expect(current_path).to eq(lockable_user_verify_authy_path)
+        expect(page).to have_content('Please enter your Authy token')
+      end
+
+      it 'does not lock out the user' do
+        fill_verify_token_form invalid_authy_token
+        user.reload
+        expect(user.access_locked?).to be_false
+      end
+
+      it 'updates fail_attempts' do
+        fill_verify_token_form invalid_authy_token
+        user.reload
+        expect(user.failed_attempts).to eq(1)
+      end
+
+    end
+
+    context 'max failed attempts exceeded' do
+
+      it 'locks the account' do
+        lock_user_account
+        user.reload
+        expect(user.locked_at).not_to be_nil
+      end
+
+      it 'signs the user out' do
+        lock_user_account
+        visit root_path
+        expect(current_path).to eq(new_user_session_path)
+      end
+
+      it 'redirects to after_sign_out_path' do
+        lock_user_account
+        expect(current_path).to eq(new_user_session_path)
+      end
+
+    end
+
+  end
+
+  context 'user enters correct code' do
+
+    it 'redirects' do
+      fill_verify_token_form valid_authy_token
+      expect(current_path).not_to eq(lockable_user_verify_authy_path)
+    end
+
+    it 'does not lock the account' do
+      fill_verify_token_form valid_authy_token
+      user.reload
+      expect(user.access_locked?).to be_false
+    end
+
+    it 'does not modify failed_attempts' do
+      fill_verify_token_form valid_authy_token
+      user.reload
+      expect(user.failed_attempts).to eq(0)
+    end
+
+  end
+
+end

--- a/spec/models/authy_lockable_spec.rb
+++ b/spec/models/authy_lockable_spec.rb
@@ -28,6 +28,11 @@ describe Devise::Models::AuthyLockable do
         expect(user.failed_attempts).to eq(1)
       end
 
+      it 'updates failed_attempts' do
+        10.times { user.invalid_authy_attempt! }
+        expect(user.failed_attempts).to eq(10)
+      end
+
       it 'respects the maximum attempts configuration for Devise::Models::Lockable' do
         4.times { user.invalid_authy_attempt! }
         expect(user.send :attempts_exceeded?).to be_true # protected method

--- a/spec/models/authy_lockable_spec.rb
+++ b/spec/models/authy_lockable_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe Devise::Models::AuthyLockable do
+
+  context 'model includes Devise::Models::Lockable' do
+
+    let(:user) { create_lockable_user authy_id: '20' }
+
+    context '#lockable?' do
+
+      it 'returns true if lock_strategy is :failed_attempts' do
+        expect(user.lockable?).to be_true
+      end
+
+      it 'returns false if lock_strategy is anything other than :failed attempts' do
+        Devise.lock_strategy = :none
+        expect(user.lockable?).to be_false
+        Devise.lock_strategy = :failed_attempts
+      end
+
+    end
+
+    context '#invalid_authy_attempt!' do
+
+      it 'resets failed_attempts to 0 if nil' do
+        user.update_attribute :failed_attempts, nil
+        user.invalid_authy_attempt!
+        expect(user.failed_attempts).to eq(1)
+      end
+
+      it 'respects the maximum attempts configuration for Devise::Models::Lockable' do
+        4.times { user.invalid_authy_attempt! }
+        expect(user.send :attempts_exceeded?).to be_true # protected method
+        expect(user.access_locked?).to be_true
+      end
+
+      it 'returns true if the account is locked' do
+        3.times { user.invalid_authy_attempt! }
+        expect(user.invalid_authy_attempt!).to be_true
+      end
+
+      it 'returns false if the account is not locked' do
+        expect(user.invalid_authy_attempt!).to be_false
+      end
+
+    end
+
+  end
+
+  context 'model does not include Devise::Models::Lockable' do
+
+    let(:user) { create_user authy_id: '20' }
+
+    context '#lockable?' do
+
+      it 'returns false' do
+        expect(user.lockable?).to be_false
+      end
+
+    end
+
+    context '#invalid_authy_attempt!' do
+
+      it "doesn't affect anything" do
+        expect(user.invalid_authy_attempt!).to be_false
+        expect(user.failed_attempts).to be_nil
+      end
+
+    end
+
+  end
+
+end

--- a/spec/models/authy_lockable_spec.rb
+++ b/spec/models/authy_lockable_spec.rb
@@ -47,23 +47,26 @@ describe Devise::Models::AuthyLockable do
 
   end
 
-  context 'model does not include Devise::Models::Lockable' do
+  context 'model misconfigured, includes AuthyLockable w/out Lockable' do
 
-    let(:user) { create_user authy_id: '20' }
+    let(:user) do
+      u = create_user authy_id: '20'
+      u.extend Devise::Models::AuthyLockable
+      u
+    end
 
     context '#lockable?' do
 
-      it 'returns false' do
-        expect(user.lockable?).to be_false
+      it 'raises an error' do
+        expect { user.lockable? }.to raise_error 'Devise lockable extension required'
       end
 
     end
 
     context '#invalid_authy_attempt!' do
 
-      it "doesn't affect anything" do
-        expect(user.invalid_authy_attempt!).to be_false
-        expect(user.failed_attempts).to be_nil
+      it 'raises an error' do
+        expect { user.invalid_authy_attempt! }.to raise_error 'Devise lockable extension required'
       end
 
     end

--- a/spec/rails-app/app/controllers/welcome_controller.rb
+++ b/spec/rails-app/app/controllers/welcome_controller.rb
@@ -1,6 +1,13 @@
 class WelcomeController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter :authenticate_scope!
 
   def index
+  end
+
+  def authenticate_scope!
+    scope = lockable_user_signed_in? ? 'lockable_user'
+                                     : 'user'
+    Rails.logger.debug "\nauthenticate_#{scope}!"
+    send "authenticate_#{scope}!", force: true
   end
 end

--- a/spec/rails-app/app/models/lockable_user.rb
+++ b/spec/rails-app/app/models/lockable_user.rb
@@ -1,0 +1,7 @@
+# User for testing out the account locking on failure.
+#
+class LockableUser < User
+  devise :authy_authenticatable, :authy_lockable, :database_authenticatable,
+         :registerable, :recoverable, :rememberable, :trackable, :validatable,
+         :lockable
+end

--- a/spec/rails-app/app/models/user.rb
+++ b/spec/rails-app/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
-  devise :authy_authenticatable, :database_authenticatable, :registerable,
+  devise :authy_authenticatable, :authy_lockable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
   # Setup accessible (or protected) attributes for your model

--- a/spec/rails-app/app/models/user.rb
+++ b/spec/rails-app/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
-  devise :authy_authenticatable, :authy_lockable, :database_authenticatable, :registerable,
+  devise :authy_authenticatable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
   # Setup accessible (or protected) attributes for your model

--- a/spec/rails-app/config/initializers/devise.rb
+++ b/spec/rails-app/config/initializers/devise.rb
@@ -141,7 +141,7 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
   # config.unlock_keys = [ :email ]
@@ -151,14 +151,14 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :time
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 3
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
   # ==> Configuration for :recoverable
   #

--- a/spec/rails-app/config/routes.rb
+++ b/spec/rails-app/config/routes.rb
@@ -2,6 +2,7 @@ RailsApp::Application.routes.draw do
   get "welcome/index"
 
   devise_for :users
+  devise_for :lockable_users, class: 'LockableUser' # for testing authy_lockable
 
   root :to => 'welcome#index'
 end

--- a/spec/rails-app/db/migrate/20130419164907_devise_create_users.rb
+++ b/spec/rails-app/db/migrate/20130419164907_devise_create_users.rb
@@ -26,9 +26,9 @@ class DeviseCreateUsers < ActiveRecord::Migration
       # t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
-      # t.integer  :failed_attempts, :default => 0 # Only if lock strategy is :failed_attempts
-      # t.string   :unlock_token # Only if unlock strategy is :email or :both
-      # t.datetime :locked_at
+      t.integer  :failed_attempts, :default => 0 # Only if lock strategy is :failed_attempts
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
 
       ## Token authenticatable
       # t.string :authentication_token

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -25,6 +25,7 @@ end
 def fill_sign_in_form(email, password, form_selector = nil, sign_in_path = nil)
   form_selector ||= '#new_user'
   sign_in_path  ||= new_user_session_path
+
   visit sign_in_path
   within(form_selector) do
     fill_in 'Email', :with => email
@@ -36,6 +37,11 @@ end
 def fill_verify_token_form(token)
   within('#devise_authy') { fill_in 'authy-token', with: token }
   click_on 'Check Token'
+end
+
+def fill_in_verify_authy_installation_form(token)
+  fill_in 'authy-token', with: token
+  click_on 'Enable my account'
 end
 
 def sign_cookie(name, val)
@@ -57,4 +63,16 @@ end
 
 def lock_user_account
   too_many_failed_attempts.times { fill_verify_token_form invalid_authy_token }
+end
+
+def assert_at(path)
+  expect(current_path).to eq(path)
+end
+
+def assert_not_at(path)
+  expect(current_path).not_to eq(path)
+end
+
+def assert_account_locked_for(user, is_locked = true)
+  expect(user.access_locked?).to eq(is_locked)
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -22,16 +22,39 @@ def create_lockable_user(attributes={})
   LockableUser.create!(valid_attributes(attributes))
 end
 
-def fill_sign_in_form(email, password)
-  visit new_user_session_path
-  within("#new_user") do
+def fill_sign_in_form(email, password, form_selector = nil, sign_in_path = nil)
+  form_selector ||= '#new_user'
+  sign_in_path  ||= new_user_session_path
+  visit sign_in_path
+  within(form_selector) do
     fill_in 'Email', :with => email
     fill_in 'Password', :with => password
   end
   click_on 'Sign in'
 end
 
+def fill_verify_token_form(token)
+  within('#devise_authy') { fill_in 'authy-token', with: token }
+  click_on 'Check Token'
+end
+
 def sign_cookie(name, val)
   verifier = ActiveSupport::MessageVerifier.new(RailsApp::Application.config.secret_token)
   verifier.generate(val)
+end
+
+def too_many_failed_attempts
+  Devise.maximum_attempts + 1
+end
+
+def valid_authy_token
+  '0000000'
+end
+
+def invalid_authy_token
+  '999999'
+end
+
+def lock_user_account
+  too_many_failed_attempts.times { fill_verify_token_form invalid_authy_token }
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -18,6 +18,10 @@ def create_user(attributes={})
   User.create!(valid_attributes(attributes))
 end
 
+def create_lockable_user(attributes={})
+  LockableUser.create!(valid_attributes(attributes))
+end
+
 def fill_sign_in_form(email, password)
   visit new_user_session_path
   within("#new_user") do


### PR DESCRIPTION
This enables the same functionality as the Devise Lockable extension, at the Authy code verification level. When configured properly, a user's account will be locked after too many failed verification code entries. It follows the same rules as the devise lockable extension, just applied to Authy code entry. 

What's New?
===
* DeviseAuthyLockable module. Provides logic for a model registered as a devise extension.
* AuthyLockable Feature RSpec coverage.
* Devise::Models::AuthyLockable RSpec coverage.


What's Changed?
===
* DeviseAuthyController - Failed attempt login has been moved to a method that either behaves normally, or performs the new locking logic.
* DeviseAuthyController RSpec tests updated.
* Additional helper methods in spec/support/helpers.rb.
* Rails App in Spec has additional routes, authentication tweaks to support lockable users in addition to non-lockable users.

What's Fixed?
===
* AuthyAuthenticatable RSpec tests have removed duplicate visit requests.

