### PR TITLE
fix typo on initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [https://github.com/authy/authy-devise/tree/master/authy-devise-demo](https:
 
 ## Getting started
 
-First create an initializer in `config/initializer/authy.rb`
+First create an initializer in `config/initializers/authy.rb`
 
 ```ruby
 Authy.api_key = ENV['AUTHY_API_KEY'] || 'your_authy_api_key'


### PR DESCRIPTION
It appears that when I tried to copy and paste instruction to terminal, it said can't be save because the typo in directory name.