### PR TITLE
Include Authy migration generator in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,12 @@ Add `Devise Authy` to your App:
 
 ### Configuring Models
 
-Configure your Devise user model:
+Configure your Devise user model either by using the generator:
 
     rails g devise_authy [MODEL_NAME]
 
-or add the following line to your `User` model
+or by manually adding the Authy strategy to your user model (`devise :authy_authenticatable, :database_authenticatable`) and generating the required migration (`rails g active_record:devise_authy [MODEL_NAME]`).
 
-```ruby
-devise :authy_authenticatable, :database_authenticatable
-```
 
 Change the default routes to point to something sane like:
 


### PR DESCRIPTION
I hope this minor documentation change makes it clearer that, if someone chooses to configure their user model manually, they need to generate the Authy migration with the ActiveRecord generator in addition to adding the strategy to the model.

I'm proposing this change because I attempted to configure my model without the generator and it took a little bit of work to figure out that I was missing a generator and how to get it. Let me know if you don't think this is clear enough - I'm happy to take another shot at organizing this in a way that makes sense. Thanks!