### PR TITLE
Require installation verification

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -142,6 +142,10 @@ class Devise::DeviseAuthyController < DeviseController
     if @resource.nil?
       @resource = resource_class.find_by_id(session["#{resource_name}_id"])
     end
+
+    if @resource.nil? && session.key?(:pre_auth_resource_id)
+      @resource = resource_class.find_by_id(session[:pre_auth_resource_id])
+    end
   end
 
   def find_resource_and_require_password_checked

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -98,8 +98,8 @@ class Devise::DeviseAuthyController < DeviseController
   end
 
   def POST_verify_authy_installation
-    self.resource = session[:pre_auth_resource_id]
-    session.delete(:pre_auth_resource)
+    self.resource = Kernel.const_get(resource_name.to_s.capitalize).find(session[:pre_auth_resource_id])
+    session.delete(:pre_auth_resource_id)
 
     token = Authy::API.verify({
       :id => self.resource.authy_id,


### PR DESCRIPTION
This PR prevents a user from hitting the application without entering
a verification token.

Without this PR, the following is possible:

1. A user who has not enabled Authy yet hits the application
2. The user enters a phone number to turn Authy on
3. Instead of entering a token at the `verify-installation` endpoint, the
user navigates to another page. Because the user is signed in, they can access the application normally.

This was only an issue for that first session where Authy is first enabled. After
entering a phone number and enabling Authy, subsequent sessions require an Authy
token even if the user doesn't successfully POST to the `verify-installation` route.

I believe this resolves #43, but if not I'd welcome any feedback that would help me turn this PR into something merge-worthy. Thanks!