### PR TITLE
Add support for phone call verification

### DIFF
--- a/app/assets/javascripts/devise_authy.js
+++ b/app/assets/javascripts/devise_authy.js
@@ -3,5 +3,8 @@ $(document).ready(function() {
   $('a#authy-request-sms-link').bind('ajax:success', function(evt, data, status, xhr) {
     alert(data.message);
   });
+  $('a#authy-request-phone-call-link').bind('ajax:success', function(evt, data, status, xhr) {
+    alert(data.message);
+  });
 });
 

--- a/app/assets/javascripts/devise_authy.js
+++ b/app/assets/javascripts/devise_authy.js
@@ -3,6 +3,8 @@ $(document).ready(function() {
   $('a#authy-request-sms-link').bind('ajax:success', function(evt, data, status, xhr) {
     alert(data.message);
   });
+
+  $('a#authy-request-phone-call-link').unbind('ajax:success');
   $('a#authy-request-phone-call-link').bind('ajax:success', function(evt, data, status, xhr) {
     alert(data.message);
   });

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -1,6 +1,6 @@
 class Devise::DeviseAuthyController < DeviseController
   prepend_before_filter :find_resource, :only => [
-    :request_sms
+    :request_phone_call, :request_sms
   ]
   prepend_before_filter :find_resource_and_require_password_checked, :only => [
     :GET_verify_authy, :POST_verify_authy
@@ -109,6 +109,16 @@ class Devise::DeviseAuthyController < DeviseController
       set_flash_message(:notice, :enabled)
       redirect_to after_authy_verified_path_for(resource)
     end
+  end
+
+  def request_phone_call
+    unless @resource
+      render :json => { :sent => false, :message => "User couldn't be found." }
+      return
+    end
+
+    response = Authy::API.request_phone_call(:id => @resource.authy_id, :force => true)
+    render :json => { :sent => response.ok?, :message => response.message }
   end
 
   def request_sms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
     cellphone: 'Enter your cellphone'
     country: 'Enter you country'
     request_sms: 'Request SMS'
+    request_phone_call: 'Request phone call'
     remember_device: 'Remember Device'
 
     authy_verify_installation_title: "Verify your account"

--- a/lib/devise-authy/controllers/view_helpers.rb
+++ b/lib/devise-authy/controllers/view_helpers.rb
@@ -1,6 +1,15 @@
 module DeviseAuthy
   module Views
     module Helpers
+      def authy_request_phone_call_link
+        link_to(
+          I18n.t('request_phone_call', { :scope => 'devise' }),
+          url_for([resource_name, :request_phone_call]),
+          :id => "authy-request-phone-call-link",
+          :method => :post,
+          :remote => true
+        )
+      end
 
       def authy_request_sms_link
         link_to(

--- a/lib/devise-authy/routes.rb
+++ b/lib/devise-authy/routes.rb
@@ -16,6 +16,7 @@ module ActionDispatch::Routing
 
 
       match "/request-sms", :controller => controllers[:devise_authy], :action => :request_sms, :as => :request_sms, :via => :post
+      match "/request-phone-call", :controller => controllers[:devise_authy], :action => :request_phone_call, :as => :request_phone_call, :via => :post
     end
   end
 end


### PR DESCRIPTION
It appears that getting a token via phone call isn't a standard part
of Authy, but is something they offer and support. This commit adds
a view helper, route, and controller action so that all of the pieces
to support phone call tokens are there. With this in the gem,
developers who want to offer phone call verification can add it easily
by extending the partials supplied by this gem.