### PR TITLE
Set resource attribute authy_enabled to TRUE when enabled

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -59,7 +59,10 @@ class Devise::DeviseAuthyController < DeviseController
     )
 
     if @authy_user.ok?
-      resource.authy_id = @authy_user.id
+      resource.update_attributes({
+        authy_id: @authy_user.id,
+        authy_enabled: true
+      })
       if resource.save
         set_flash_message(:notice, :enabled)
       else


### PR DESCRIPTION
authy_enabled was not getting set to true after successfully passing verification and being enabled with the Authy service. This pull request sets the attribute to true.