### PR TITLE
Replaced alias_method_chain with Module#prepend approach

### DIFF
--- a/lib/devise-authy/mapping.rb
+++ b/lib/devise-authy/mapping.rb
@@ -1,14 +1,10 @@
 module DeviseAuthy
   module Mapping
-    def self.included(base)
-      base.alias_method_chain :default_controllers, :authy_authenticatable
-    end
-
     private
-    def default_controllers_with_authy_authenticatable(options)
+    def default_controllers(options)
       options[:controllers] ||= {}
       options[:controllers][:passwords] ||= "devise_authy/passwords"
-      default_controllers_without_authy_authenticatable(options)
+      super
     end
   end
 end

--- a/lib/devise-authy/rails.rb
+++ b/lib/devise-authy/rails.rb
@@ -9,7 +9,7 @@ module DeviseAuthy
 
     # extend mapping with after_initialize because it's not reloaded
     config.after_initialize do
-      Devise::Mapping.send :include, DeviseAuthy::Mapping
+      Devise::Mapping.send :prepend, DeviseAuthy::Mapping
     end
   end
 end


### PR DESCRIPTION
This fixes compatibility with https://github.com/scambra/devise_invitable and `Module#prepend` is also generally more intuitive.

Blog posts:
https://hashrocket.com/blog/posts/module-prepend-a-super-story
http://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain