### PR TITLE
use before_action instead and fix before_filter deprication warning

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -1,11 +1,11 @@
 class Devise::DeviseAuthyController < DeviseController
-  prepend_before_filter :find_resource, :only => [
+  prepend_before_action :find_resource, :only => [
     :request_phone_call, :request_sms
   ]
-  prepend_before_filter :find_resource_and_require_password_checked, :only => [
+  prepend_before_action :find_resource_and_require_password_checked, :only => [
     :GET_verify_authy, :POST_verify_authy
   ]
-  prepend_before_filter :authenticate_scope!, :only => [
+  prepend_before_action :authenticate_scope!, :only => [
     :GET_enable_authy, :POST_enable_authy,
     :GET_verify_authy_installation, :POST_verify_authy_installation,
     :POST_disable_authy

--- a/authy-devise-demo/README.md
+++ b/authy-devise-demo/README.md
@@ -37,7 +37,7 @@
 
 8. Edit `app/controllers/welcome_controller.rb` and add:
 
-	    before_filter :authenticate_user!
+	    before_action :authenticate_user!
 
 
 9. Edit `app/views/welcome/index.html.erb` and add:

--- a/authy-devise-demo/app/controllers/welcome_controller.rb
+++ b/authy-devise-demo/app/controllers/welcome_controller.rb
@@ -1,6 +1,6 @@
 class WelcomeController < ApplicationController
-  before_filter :authenticate_user!, only: "user_page"
-  before_filter :authenticate_admin!, only: "admin_page"
+  before_action :authenticate_user!, only: "user_page"
+  before_action :authenticate_admin!, only: "admin_page"
 
   def index
     redirect_to welcome_admin_page_path if current_admin

--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -4,7 +4,7 @@ module DeviseAuthy
       extend ActiveSupport::Concern
 
       included do
-        before_filter :check_request_and_redirect_to_verify_token, :if => :is_signing_in?
+        before_action :check_request_and_redirect_to_verify_token, :if => :is_signing_in?
       end
 
       private

--- a/spec/rails-app/app/controllers/welcome_controller.rb
+++ b/spec/rails-app/app/controllers/welcome_controller.rb
@@ -1,5 +1,5 @@
 class WelcomeController < ApplicationController
-  before_filter :authenticate_scope!
+  before_action :authenticate_scope!
 
   def index
   end


### PR DESCRIPTION
Using `before_filter` produces deprecation warning in Rails 5.0.0.1

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.
```