### PR TITLE
Make remember_device account specific (Fixed specs)

### DIFF
--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -21,6 +21,8 @@ module DeviseAuthy
         id = warden.session(resource_name)[:id]
         cookie = cookies.signed[:remember_device]
 
+        return true if cookie.blank?
+
         # backwords compatibility for old cookies which just have expiration
         # time and no id
         if cookie.to_s =~ %r{\A\d+\Z}

--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -9,17 +9,22 @@ module DeviseAuthy
 
       private
       def remember_device
+        id = @resource.id
         cookies.signed[:remember_device] = {
-          :value => Time.now.to_i,
+          :value => {expires: Time.now.to_i, id: id}.to_json,
           :secure => !(Rails.env.test? || Rails.env.development?),
           :expires => resource_class.authy_remember_device.from_now
         }
       end
 
       def require_token?
-        if cookies.signed[:remember_device].present? &&
-          (Time.now.to_i - cookies.signed[:remember_device].to_i) < \
-          resource_class.authy_remember_device.to_i
+        byebug
+        id = warden.session(resource_name)[:id]
+        cookie = JSON.parse(cookies.signed[:remember_device])
+        if cookie.present? &&
+          (Time.now.to_i - cookie['expires'].to_i) < \
+          resource_class.authy_remember_device.to_i &&
+          cookie['id'] == id
           return false
         end
 

--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -18,7 +18,6 @@ module DeviseAuthy
       end
 
       def require_token?
-        byebug
         id = warden.session(resource_name)[:id]
         cookie = JSON.parse(cookies.signed[:remember_device])
         if cookie.present? &&


### PR DESCRIPTION
Follow up to #59 except with the specs broken in the PR fixed. // @Gasparila / @vargasx 

That said, currently `master`is failing for:

```
rspec ./spec/controllers/devise_authy_controller_spec.rb:32 # Devise::DeviseAuthyController POST #verify_authy Should login the user if token is ok
rspec ./spec/controllers/devise_authy_controller_spec.rb:46 # Devise::DeviseAuthyController POST #verify_authy Should set remember_device if selected
rspec ./spec/controllers/devise_authy_controller_spec.rb:211 # Devise::DeviseAuthyController POST #verify_authy_installation Should enable authy for user
rspec ./spec/controllers/devise_authy_controller_spec.rb:235 # Devise::DeviseAuthyController POST #request_sms Should send sms if user is logged
rspec ./spec/features/authy_authenticatable_spec.rb:28 # Authy Authenticatable If user has two factor authentication Sign in should succeed
rspec ./spec/features/authy_authenticatable_spec.rb:84 # Authy Authenticatable If user has two factor authentication Click link Request sms
```
