### PR TITLE
Always require token when user has an old cookie

### DIFF
--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -20,17 +20,12 @@ module DeviseAuthy
       def require_token?
         id = warden.session(resource_name)[:id]
         cookie = cookies.signed[:remember_device]
-
         return true if cookie.blank?
 
-        # backwords compatibility for old cookies which just have expiration
-        # time and no id
-        if cookie.to_s =~ %r{\A\d+\Z}
-          return (Time.now.to_i - cookie.to_i) > \
-                 resource_class.authy_remember_device.to_i
-        end
+        # require token for old cookies which just have expiration time and no id
+        return true if cookie.to_s =~ %r{\A\d+\z}
 
-        cookie = JSON.parse(cookie)
+        cookie = JSON.parse(cookie) rescue ""
         return cookie.blank? || (Time.now.to_i - cookie['expires'].to_i) > \
                resource_class.authy_remember_device.to_i || cookie['id'] != id
       end


### PR DESCRIPTION
For security purpose because the old cookie wasn't account specific. See #58