### PR TITLE
Fix for security hole where user can bypass 2fa

### DIFF
--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -53,7 +53,8 @@ module DeviseAuthy
 
           remember_me = (params.fetch(resource_name, {})[:remember_me].to_s == "1")
           return_to = session["#{resource_name}_return_to"]
-          sign_out
+          sign_out resource_name
+          warden.lock!
 
           session["#{resource_name}_id"] = id
           # this is safe to put in the session because the cookie is signed
@@ -62,7 +63,6 @@ module DeviseAuthy
           session["#{resource_name}_return_to"] = return_to if return_to
 
           redirect_to verify_authy_path_for(resource_name)
-          return
         end
       end
 

--- a/spec/controllers/devise_sessions_controller_spec.rb
+++ b/spec/controllers/devise_sessions_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Devise::SessionsController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  before :each do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  let(:user){ create_user(password: "12345678") }
+
+  describe "POST #create" do
+    context "without 2fa enabled" do
+      it "Logs in user without redirecting to verify authy page" do
+        post :create, user: { email: user.email, password: "12345678"  }
+        expect(flash.now[:notice]).to eq("Signed in successfully.")
+        expect(response).to redirect_to(root_url)
+
+        expect(controller.current_user).to eq(user)
+        
+        # Visiting the new session page flashes "already signed in" message
+        get :new
+        expect(flash.now[:alert]).to eq("You are already signed in.")
+      end
+    end
+
+    context "with 2fa enabled" do
+      let(:user){ create_user(authy_id: 2, password: "12345678", authy_enabled: true) }
+
+      it "Does not login user and does not set a current_user" do
+        post :create, user: { email: user.email, password: "12345678"  }
+        expect(response).to redirect_to(user_verify_authy_path)
+
+        expect(controller.current_user).to eq(nil)
+
+        # Visiting the new session page, does not flash the "already signed in" message
+        get :new
+        expect(flash.now[:alert]).to_not eq("You are already signed in.")
+        expect(response).to_not redirect_to(root_url)
+      end
+    end
+  end
+end

--- a/spec/features/authy_authenticatable_spec.rb
+++ b/spec/features/authy_authenticatable_spec.rb
@@ -40,6 +40,14 @@ describe "Authy Authenticatable", :type => :request do
       expect(@user.last_sign_in_with_authy).not_to be_nil
     end
 
+    it "Sign in should not sign in user until they verify authy token" do
+      fill_sign_in_form(@user.email, '12345678')
+      expect(current_path).to eq(user_verify_authy_path)
+
+      visit new_user_session_path
+      expect(page).to_not have_content "Logout"
+    end
+
     it "Sign in shouldn't succeed" do
       fill_sign_in_form(@user.email, '12345678')
       expect(current_path).to eq(user_verify_authy_path)


### PR DESCRIPTION
Because the `warden` variable was not locked after we signed out the
user, the user would get logged in (bypassing the 2fa completely) before
they verified their token.