### PR TITLE
Record Authy Authentication After Successfully Verifying Installation

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -104,13 +104,14 @@ class Devise::DeviseAuthyController < DeviseController
     self.resource.authy_enabled = token.ok?
 
     if token.ok? && self.resource.save
+      record_authy_authentication
       set_flash_message(:notice, :enabled)
       redirect_to after_authy_verified_path_for(resource)
     else
       handle_invalid_token :verify_authy_installation, :not_enabled
     end
   end
-  
+
   def GET_authy_onetouch_status
     status = Authy::API.get_request("onetouch/json/approval_requests/#{params[:onetouch_uuid]}")['approval_request']['status']
     case status

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -239,6 +239,7 @@ describe Devise::DeviseAuthyController, type: :controller do
     it "Should enable authy for user" do
       sign_in @user
       post :POST_verify_authy_installation, :token => "0000000"
+      expect(session["user_authy_token_checked"]).to be_truthy
       expect(response).to redirect_to(root_url)
       expect(flash[:notice]).to eq('Two factor authentication was enabled')
 


### PR DESCRIPTION
The `POST_verify_authy_installation` after successful verification does not invoke `record_authy_authentication` method so some resources are not updated after very first time 2FA setup such as the `last_sign_in_with_authy` attribute on the model and the `session["#{resource_name}_authy_token_checked"]` session key.

This prevents one from using the [`session["user_authy_token_checked"]`](https://github.com/authy/authy-devise#session-variables) session key to check if user has been successfully verified/logged in with 2FA first-time.

PR to Fix for Issue #86 

