### PR TITLE
Forget the remember_device cookie when disabling Authy

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -81,6 +81,7 @@ class Devise::DeviseAuthyController < DeviseController
     if response.ok?
       resource.update_attribute(:authy_enabled, false)
       resource.update_attribute(:authy_id, nil)
+      forget_device
 
       set_flash_message(:notice, :disabled)
     else

--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -8,6 +8,7 @@ module DeviseAuthy
       end
 
       private
+
       def remember_device
         id = @resource.id
         cookies.signed[:remember_device] = {
@@ -15,6 +16,10 @@ module DeviseAuthy
           :secure => !(Rails.env.test? || Rails.env.development?),
           :expires => resource_class.authy_remember_device.from_now
         }
+      end
+
+      def forget_device
+        cookies.delete :remember_device
       end
 
       def require_token?

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -193,7 +193,15 @@ describe Devise::DeviseAuthyController, type: :controller do
       sign_in @user
       @user.update_attribute(:authy_enabled, true)
 
+      request.cookies["remember_device"] = {
+        :value => {expires: Time.now.to_i, id: @user.id}.to_json,
+        :secure => false,
+        :expires => User.authy_remember_device.from_now
+      }
+
       post :POST_disable_authy
+
+      expect(response.cookies["remember_device"]).to be_nil
       @user.reload
       expect(@user.authy_id).to be_nil
       expect(@user.authy_enabled).to be_falsey


### PR DESCRIPTION
Fixes #65.